### PR TITLE
Allow content and loaded scripts to be customisable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You can customise the standard consent banner by passing options, either in .env
 - STYLE_CONTENT: Custom styles for the consent banner. Defaults to those outlined in ```consent-banner.template.css``` in the package. You can copy this template to help you customise the styles.
 - USE_EXTERNAL_STYLESHEET: use this instead of STYLE_CONTENT to link to an external stylesheet provied by your application. You can copy the template above to your own stylesheet to help you customise the styles.
 - BUTTON_ELEMENT: If you are using your own stylesheet you may prefer to use a different element for the accept/reject buttons. Defaults to "button".
+- BUTTON_CONTENT: Use this to add HTML content such as an SVG icon after the Accept/Reject button text. Defaults to none.
 - BUTTON_CLASS: If you are using your own stylesheet you may prefer your own class name for the button styling. Defaults to "_barnardos-consent-banner__button".
 - CLOSE_BUTTON_ELEMENT: If you are using your own stylesheet you may prefer to use a different element for the close button. Defaults to "button".
 - CLOSE_BUTTON_CLASS: If you are using your own stylesheet you may prefer your own class name for the close button styling. Defaults to "_barnardos-cookie-close".

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Option 1: npm install / yarn add
 
-Run `npm install @barnardoswebteam/consent-banner` or `yarn add @barnardoswebteam/consent-banner`.
+Run `npm install @barnardoswebteam/customisable-consent-banner` or `yarn add @barnardoswebteam/customisable-consent-banner`.
 
 For the standard consent banner, in your code add the following:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Run `npm install @barnardoswebteam/consent-banner` or `yarn add @barnardoswebteam/consent-banner`.
 
-In your code add the following:
+For the standard consent banner, in your code add the following:
 
 ```js
 const consentBanner = require('@barnardoswebteam/consent-banner');
@@ -15,11 +15,26 @@ consentBanner();
 
 And add the GTM container ID in .env or as a config variable as `GTM_CODE`.
 
-Optionally add URLs for your privacy policy and cookie policy in .env as `PRIVACY_URL` and `COOKIE_URL`. If no privacy URL is declared it defaults to https://www.barnardos.org.uk/privacy-notice, and if no cookie URL is declared it defaults to https://www.barnardos.org.uk/cookie-notice.
+You can customise the standard consent banner by passing options, either in .env in block-caps snake case, or as camelCase config variables in an options hash.
+
+- PRIVACY_URL: URL for your privacy policy. Defaults to https://www.barnardos.org.uk/privacy-notice.
+- COOKIE_URL: URL for your cookie policy. Defaults to https://www.barnardos.org.uk/cookie-notice.
+- BANNER_HEADING: Heading text for the consent banner. Defaults to "Cookie tracking preferences".
+- BANNER_CONTENT: Custom text content (but not buttons)
+- CLOSE_BUTTON_CONTENT: Custom text or an svg for the close button. Defaults to "&#x2715;".
+- ADDITIONAL_SCRIPTS: Additional tracking scripts to be ran when the consent banner is accepted. If you have other scripts to use instead, GTM_CODE is optional and omitting it will prevent the banner attempting to load GTM scripts. Defaults to none.
+- RELOAD_ON_ACCEPT: set this to ```true``` to set the cookie and then reload the page if you have scripts which cannot be provided above for architectural reasons, and which have loaded with defaults that cannot be easily toggled at run time. Defaults to ```false```.
+- STYLE_CONTENT: Custom styles for the consent banner. Defaults to those outlined in ```consent-banner.template.css``` in the package. You can copy this template to help you customise the styles.
+- USE_EXTERNAL_STYLESHEET: use this instead of STYLE_CONTENT to link to an external stylesheet provied by your application. You can copy the template above to your own stylesheet to help you customise the styles.
+- BUTTON_ELEMENT: If you are using your own stylesheet you may prefer to use a different element for the buttons. Defaults to "button".
+- BUTTON_CLASS: If you are using your own stylesheet you may prefer your own class name for the button styling. Defaults to "_barnardos-consent-banner__button".
+- CLOSE_BUTTON_CLASS: If you are using your own stylesheet you may prefer your own class name for the close button styling. Defaults to "_barnardos-cookie-close".
+
+If you have extensively customised the styles and the banner content, you can reduce the size of your JavaScript by bypassing the ```ConsentBanner``` wrapper (```barnardosConsent``` if using es5) and calling ```ConsentBanner.Custom``` (or ```barnardosCustomConsent``` if using es5) directly to avoid loading the redundant default styles and content.
 
 ### Option 2: <abbr title="ECMAScript Module">ESM</a>
 
-In your HTML add the following:
+For the standard consent banner, in your HTML add the following:
 
 ```html
 <script type="module" src="main.js"></script>
@@ -33,25 +48,25 @@ consentBanner();
 
 And add the GTM container ID in .env or as a config variable as `GTM_CODE`.
 
-Optionally add URLs for your privacy policy and cookie policy in .env as `PRIVACY_URL` and `COOKIE_URL`. If no privacy URL is declared it defaults to https://www.barnardos.org.uk/privacy-notice, and if no cookie URL is declared it defaults to https://www.barnardos.org.uk/cookie-notice.
+You can customise the standard consent banner by passing options, either in .env in block-caps snake case, or as camelCase config variables in an options hash. See Option 1 above for option syntax.
 
 ### Option 3: script element in HTML
 
-Put the following near the end of the body element, replacing GTM-XXXXXX with the correct ID.
+For the standard consent banner, put the following near the end of the body element, replacing GTM-XXXXXX with the correct ID.
 
 ```html
 <script src="path/to/consent-banner.es5.js"></script>
 <script>BarnardosConsent({'gtmCode':'GTM-XXXXXX'});</script>
 ```
 
-Self hosting is recommended but if it's not possible you can use:
+Self hosting is recommended ~~but if it's not possible you can use:~~
 
-```html
+~~```html
 <script src="https://unpkg.com/@barnardoswebteam/consent-banner@latest/consent-banner.es5.js"></script>
 <script>BarnardosConsent({'gtmCode':'GTM-XXXXXX'});</script>
-```
+```~~
 
-Optionally add URLs for your privacy policy and cookie policy to the code like so:
+You can customise the standard consent banner by passing camelCase config variables in an options hash. See Option 1 above for option syntax. For example:
 
 ```html
 <script>
@@ -59,13 +74,13 @@ BarnardosConsent(
   {
     'gtmCode': 'GTM-XXXXXX',
     'privacyURL': 'https://your-domain/privacy-policy',
-    'cookieURL': 'https://your-domain/cookie-policy'
+    'cookieURL': 'https://your-domain/cookie-policy',
+    'bannerHeading': 'Your custom heading',
+    'useExternalStylesheet': true
   }
 );
 </script>
 ```
-
-Both are optional, and if either it missing they will default to https://www.barnardos.org.uk/privacy-notice and https://www.barnardos.org.uk/cookie-notice respectively.
 
 ### Updating
 
@@ -81,6 +96,6 @@ Steps for creating a git submodule:
 
 ## Safari and Firefox
 
-Safari and Firefox now both delete scripted storage fairly quickly. In Safari's case it can be 24 hours. Therefore the consent banner is shown on repeat visits, which is making the banner even more annoying than it already is. 
+Safari and Firefox now both delete scripted storage fairly quickly. In Safari's case it can be 24 hours. Therefore the consent banner is shown on repeat visits, which is making the banner even more annoying than it already is.
 
 Therefore it's recommended re-setting the appropriate cookies with the server-side language of your choice, with a 1 year expiration. This has been cleared by the Barnardo's Head of Information Governance and Data Protection Officer.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can customise the standard consent banner by passing options, either in .env
 - BANNER_CONTENT: Custom text content (but not buttons)
 - CLOSE_BUTTON_CONTENT: Custom text or an svg for the close button. Defaults to "&#x2715;".
 - ADDITIONAL_SCRIPTS: An array of additional tracking scripts to be ran when the consent banner is accepted. If you have other scripts to use instead, GTM_CODE is optional and omitting it will prevent the banner attempting to load GTM scripts. Scripts are described by JSON objects with the properties name (arbitrary, for your reference), script (a function to execute), and args (an array of arguments to pass when the script is accepted). Defaults to none.
+- RESTRICT_DOMAIN: defaults to ```'.barnardos.org.uk'``` but you can use this to set another domain or if set to ```false``` it will allow the banner to be shown on any domain.
 - RELOAD_ON_ACCEPT: set this to ```true``` to set the cookie and then reload the page if you have scripts which cannot be provided above for architectural reasons, and which have loaded with defaults that cannot be easily toggled at run time. Defaults to ```false```.
 - STYLE_CONTENT: Custom styles for the consent banner. Defaults to those outlined in ```consent-banner.template.css``` in the package. You can copy this template to help you customise the styles.
 - USE_EXTERNAL_STYLESHEET: use this instead of STYLE_CONTENT to link to an external stylesheet provied by your application. You can copy the template above to your own stylesheet to help you customise the styles.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can customise the standard consent banner by passing options, either in .env
 - BANNER_HEADING: Heading text for the consent banner. Defaults to "Cookie tracking preferences".
 - BANNER_CONTENT: Custom text content (but not buttons)
 - CLOSE_BUTTON_CONTENT: Custom text or an svg for the close button. Defaults to "&#x2715;".
-- ADDITIONAL_SCRIPTS: Additional tracking scripts to be ran when the consent banner is accepted. If you have other scripts to use instead, GTM_CODE is optional and omitting it will prevent the banner attempting to load GTM scripts. Defaults to none.
+- ADDITIONAL_SCRIPTS: An array of additional tracking scripts to be ran when the consent banner is accepted. If you have other scripts to use instead, GTM_CODE is optional and omitting it will prevent the banner attempting to load GTM scripts. Scripts are described by JSON objects with the properties name (arbitrary, for your reference), script (a function to execute), and args (an array of arguments to pass when the script is accepted). Defaults to none.
 - RELOAD_ON_ACCEPT: set this to ```true``` to set the cookie and then reload the page if you have scripts which cannot be provided above for architectural reasons, and which have loaded with defaults that cannot be easily toggled at run time. Defaults to ```false```.
 - STYLE_CONTENT: Custom styles for the consent banner. Defaults to those outlined in ```consent-banner.template.css``` in the package. You can copy this template to help you customise the styles.
 - USE_EXTERNAL_STYLESHEET: use this instead of STYLE_CONTENT to link to an external stylesheet provied by your application. You can copy the template above to your own stylesheet to help you customise the styles.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ You can customise the standard consent banner by passing options, either in .env
 - RELOAD_ON_ACCEPT: set this to ```true``` to set the cookie and then reload the page if you have scripts which cannot be provided above for architectural reasons, and which have loaded with defaults that cannot be easily toggled at run time. Defaults to ```false```.
 - STYLE_CONTENT: Custom styles for the consent banner. Defaults to those outlined in ```consent-banner.template.css``` in the package. You can copy this template to help you customise the styles.
 - USE_EXTERNAL_STYLESHEET: use this instead of STYLE_CONTENT to link to an external stylesheet provied by your application. You can copy the template above to your own stylesheet to help you customise the styles.
-- BUTTON_ELEMENT: If you are using your own stylesheet you may prefer to use a different element for the buttons. Defaults to "button".
+- BUTTON_ELEMENT: If you are using your own stylesheet you may prefer to use a different element for the accept/reject buttons. Defaults to "button".
 - BUTTON_CLASS: If you are using your own stylesheet you may prefer your own class name for the button styling. Defaults to "_barnardos-consent-banner__button".
+- CLOSE_BUTTON_ELEMENT: If you are using your own stylesheet you may prefer to use a different element for the close button. Defaults to "button".
 - CLOSE_BUTTON_CLASS: If you are using your own stylesheet you may prefer your own class name for the close button styling. Defaults to "_barnardos-cookie-close".
 
 If you have extensively customised the styles and the banner content, you can reduce the size of your JavaScript by bypassing the ```ConsentBanner``` wrapper (```barnardosConsent``` if using es5) and calling ```ConsentBanner.Custom``` (or ```barnardosCustomConsent``` if using es5) directly to avoid loading the redundant default styles and content.

--- a/consent-banner.es5.js
+++ b/consent-banner.es5.js
@@ -1,75 +1,111 @@
-'use strict';
-
-window.BarnardosConsent = function(options) {
+"use strict";
+window.BarnardosConsent = function (options) {
   if (!options.gtmCode) {
+    return;
+  }
+  var static_defaults = {
+    privacyURL: "https://www.barnardos.org.uk/privacy-notice",
+    cookieURL: "https://www.barnardos.org.uk/cookie-notice",
+    bannerHeading: "Cookie tracking preference",
+    buttonClass: "_barnardos-consent-banner__button",
+    buttonElement: "button",
+    closeButtonContent: "&#x2715;",
+    closeButtonClass: "_barnardos-cookie-close",
+    styleContent:
+      "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}",
+  };
+  Object.keys(static_defaults).forEach((key) => {
+    options[key] = options[key] || static_defaults[key];
+  });
+  //dynamic defaults
+  options.bannerContent =
+    options.bannerContent ||
+    `We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="${options.privacyURL}">privacy policy</a> and <a href="${options.cookieURL}">cookie notice</a> for more details.`;
+  barnardosCustomConsent(options);
+};
+
+function barnardosCustomConsent(options) {
+  var missingMandatoryOptions = "missing mandatory options";
+  "bannerHeading bannerContent buttonClass buttonElement closeButtonContent closeButtonClass styleContent"
+    .split(" ")
+    .forEach(
+      (option) =>
+        (missingMandatoryOptions += options[option] ? "" : `, ${option}`),
+    );
+
+  missingMandatoryOptions +=
+    options.useExternalStylesheet || options.styleContent
+      ? ""
+      : ",styleContent";
+
+  if (missingMandatoryOptions != "missing mandatory options") {
+    console.warn(missingMandatoryOptions);
     return;
   }
 
   var gtmCode = options.gtmCode;
 
-  if(options.privacyURL) {
-    var privacyURL = options.privacyURL;
-  } else {
-    var privacyURL = 'https://www.barnardos.org.uk/privacy-notice';
-  } 
-
-  if(options.cookieURL) {
-    var cookieURL = options.cookieURL;
-  } else {
-    var cookieURL = 'https://www.barnardos.org.uk/cookie-notice';
-  }
-
-  var getCookieValue = function(name) {
+  var getCookieValue = function (name) {
     var result = document.cookie.match(
-      '(^|[^;]+)\\s*' + name + '\\s*=\\s*([^;]+)'
+      "(^|[^;]+)\\s*" + name + "\\s*=\\s*([^;]+)",
     );
-    return result ? result.pop() : '';
+    return result ? result.pop() : "";
   };
 
   // Build a button
-  var buildButton = function(text) {
-    var button = document.createElement('button');
-    button.type = 'button';
+  var buildButton = function (text) {
+    var button = document.createElement(options.buttonElement);
+    switch (options.buttonElement) {
+      case "button":
+        button.type = "button";
+      case "a":
+        button.setAttribute("href", "#");
+    }
     button.id = text.toLowerCase();
     button.textContent = text;
-    button.className = '_barnardos-consent-banner__button';
+    button.className = options.buttonClass;
     return button;
   };
 
   // Create the two buttons and a placeholder for the banner
-  var consentBanner = document.createElement('div');
-  var rejectButton = buildButton('Reject');
-  var acceptButton = buildButton('Accept');
+  var consentBanner = document.createElement("div");
+  var rejectButton = buildButton("Reject");
+  var acceptButton = buildButton("Accept");
   var cookieOverlay = document.createElement("div");
-  var closeButton = document.createElement("button");
+  var closeButton = document.createElement(options.buttonElement);
+  if (options.buttonElement == "a") {
+    closeButton.setAttribute("href", "#");
+  }
 
   // Build the banner
-  var buildBanner = function() {    
+  var buildBanner = function () {
     cookieOverlay.className = "_barnardos-cookie-overlay";
     cookieOverlay.id = "overlay";
-    consentBanner.className = '_barnardos-consent-banner';    
+    consentBanner.className = "_barnardos-consent-banner";
     consentBanner.setAttribute("role", "dialog");
     consentBanner.setAttribute("aria-modal", "true");
     consentBanner.setAttribute("aria-labelledby", "dialog-title");
     consentBanner.setAttribute("aria-describedby", "dialog-description");
-    consentBanner.setAttribute("tabindex", "-1");    
+    consentBanner.setAttribute("tabindex", "-1");
     closeButton.id = "close";
-    closeButton.className = "_barnardos-cookie-close";
+    closeButton.className = options.closeButtonClass;
     closeButton.setAttribute("aria-label", "Close cookie tracking preference");
-    closeButton.innerHTML = "&#x2715;";
+    closeButton.innerHTML = options.closeButtonContent;
     var heading = document.createElement("h2");
-    heading.textContent = "Cookie tracking preference";
+    heading.textContent = options.bannerHeading;
     heading.className = "_barnardos-cookie-heading";
     heading.id = "dialog-title";
-    var text = document.createElement('p');
+    var text = document.createElement("p");
     text.id = "dialog-description";
-    text.innerHTML = 'We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="'+ privacyURL +'">privacy policy</a> and <a href="'+ cookieURL +'">cookie notice</a> for more details.';
-    var style = document.createElement('style');
-    style.textContent = "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}";
-    consentBanner.appendChild(style);
+    text.innerHTML = options.bannerContent;
+    if (!options.useExternalStylesheet) {
+      const style = document.createElement("style");
+      style.textContent = options.styleContent;
+      consentBanner.appendChild(style);
+    }
     consentBanner.appendChild(heading);
     consentBanner.appendChild(text);
-    var buttonWrap = document.createElement('div');
+    var buttonWrap = document.createElement("div");
     buttonWrap.appendChild(rejectButton);
     buttonWrap.appendChild(acceptButton);
     consentBanner.appendChild(buttonWrap);
@@ -88,51 +124,65 @@ window.BarnardosConsent = function(options) {
   };
 
   // Close consent banner
-  var closeConsentBanner = function() {
+  var closeConsentBanner = function () {
     consentBanner.parentNode.removeChild(consentBanner);
     cookieOverlay.parentNode.removeChild(cookieOverlay);
     var expires = new Date();
     expires.setDate(expires.getDate() + 365);
     document.cookie =
-      'consentBanner=closed; expires=' +
+      "consentBanner=closed; expires=" +
       expires +
-      ';domain=.barnardos.org.uk; path=/; SameSite=Strict';
+      ";domain=.barnardos.org.uk; path=/; SameSite=Strict";
   };
 
   // Load the scripts and trackers
-  // Using the minified code GTM gives us
-  var loadScripts = function(w, d, s, l, i) {
-    w[l] = w[l] || [];
-    w[l].push({
-      'gtm.start': new Date().getTime(),
-      event: 'gtm.js'
+  options.gtmCode &&
+    (options.scripts = options.scripts || []).push({
+      // GTM script using the minified code GTM gives us
+      name: "GTM",
+      script: function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({
+          "gtm.start": new Date().getTime(),
+          event: "gtm.js",
+        });
+        var f = d.getElementsByTagName(s)[0];
+        var j = d.createElement(s);
+        var dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      },
+      args: [window, document, "script", "dataLayer", options.gtmCode],
     });
-    var f = d.getElementsByTagName(s)[0];
-    var j = d.createElement(s);
-    var dl = l != 'dataLayer' ? '&l=' + l : '';
-    j.async = true;
-    j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-    f.parentNode.insertBefore(j, f);
+  if (!options.scripts) {
+    return;
+  }
+
+  var loadScripts = function () {
+    options.scripts.forEach(function (script) {
+      script.script(...script.args);
+    });
     // Add acceptance to cookie so we can load the
     // Trackers and scripts with subsequent page views
     var expires = new Date();
     expires.setDate(expires.getDate() + 365);
     document.cookie =
-      'consentAction=accept; expires=' +
+      "consentAction=accept; expires=" +
       expires +
-      ';domain=.barnardos.org.uk; path=/; SameSite=Strict';
+      ";domain=.barnardos.org.uk; path=/; SameSite=Strict";
   };
 
   // Create a YYYY-MM date format
-  var formatDate = function(timestamp) {
+  var formatDate = function (timestamp) {
     var date = new Date(timestamp * 1000);
     var year = date.getFullYear();
-    var month = ('0' + (date.getMonth() + 1)).slice(-2);
-    return year + '-' + month;
+    var month = ("0" + (date.getMonth() + 1)).slice(-2);
+    return year + "-" + month;
   };
 
   // Send a POST request to a click tracker
-  var sendClickAction = function(closer) {
+  var sendClickAction = function (closer) {
     // Make a UNIX timestamp
     var time = Math.round(new Date().getTime() / 1000);
     var date = formatDate(time);
@@ -141,44 +191,16 @@ window.BarnardosConsent = function(options) {
       time: time,
       date: date,
       value: closer,
-      subdomain: location.hostname.split('.')[0]
+      subdomain: location.hostname.split(".")[0],
     };
     // Send the object
     if (window.XMLHttpRequest) {
       var request = new XMLHttpRequest();
       var url =
-        'https://barnardos-cors-anywhere.herokuapp.com/https://cookie-banner-click-counter.herokuapp.com/ajax-accept.php';
-      request.open('POST', url, true);
-      request.setRequestHeader('Content-type', 'application/json');
-      request.onreadystatechange = function() {
-        if (request.readyState === XMLHttpRequest.DONE) {
-          if (request.status !== 200) {
-            console.error('Error sending data to click action tracker');
-          }
-        }
-      };
-      request.send(JSON.stringify(obj));
-    }
-  };
-
-  // Send a banner load event to the counter
-  var sendLoad = function() {
-    // Make a UNIX timestamp
-    var time = Math.round(new Date().getTime() / 1000);
-    var date = formatDate(time);
-    // Build an object to send as JSON
-    var obj = {
-      time: time,
-      date: date
-    };
-    // Send the object
-    if (window.XMLHttpRequest) {
-      var request = new XMLHttpRequest();
-      var url =
-        "https://barnardos-cors-anywhere.herokuapp.com/https://cookie-banner-click-counter.herokuapp.com/ajax-load-accept.php";
+        "https://barnardos-cors-anywhere.herokuapp.com/https://cookie-banner-click-counter.herokuapp.com/ajax-accept.php";
       request.open("POST", url, true);
       request.setRequestHeader("Content-type", "application/json");
-      request.onreadystatechange = function() {
+      request.onreadystatechange = function () {
         if (request.readyState === XMLHttpRequest.DONE) {
           if (request.status !== 200) {
             console.error("Error sending data to click action tracker");
@@ -189,21 +211,49 @@ window.BarnardosConsent = function(options) {
     }
   };
 
-  var handleForwardTab = function(e) {
+  // Send a banner load event to the counter
+  var sendLoad = function () {
+    // Make a UNIX timestamp
+    var time = Math.round(new Date().getTime() / 1000);
+    var date = formatDate(time);
+    // Build an object to send as JSON
+    var obj = {
+      time: time,
+      date: date,
+    };
+    // Send the object
+    if (window.XMLHttpRequest) {
+      var request = new XMLHttpRequest();
+      var url =
+        "https://barnardos-cors-anywhere.herokuapp.com/https://cookie-banner-click-counter.herokuapp.com/ajax-load-accept.php";
+      request.open("POST", url, true);
+      request.setRequestHeader("Content-type", "application/json");
+      request.onreadystatechange = function () {
+        if (request.readyState === XMLHttpRequest.DONE) {
+          if (request.status !== 200) {
+            console.error("Error sending data to click action tracker");
+          }
+        }
+      };
+      request.send(JSON.stringify(obj));
+    }
+  };
+
+  var handleForwardTab = function (e) {
     if (document.activeElement === lastFocusableElement) {
       e.preventDefault();
       firstFocusableElement.focus();
     }
   };
 
-  var handleBackwardTab = function(e) {
+  var handleBackwardTab = function (e) {
     if (document.activeElement === firstFocusableElement) {
       e.preventDefault();
       lastFocusableElement.focus();
     }
   };
 
-  if (getCookieValue('consentBanner') !== 'closed') {
+  if (getCookieValue("consentBanner") !== "closed") {
     // Check if the banner has been loaded and if not send a session load to the counter
     if (sessionStorage.consentBannerSessionLoad !== "loaded") {
       sendLoad();
@@ -214,42 +264,43 @@ window.BarnardosConsent = function(options) {
 
   // If cookies are previously accepted run the function
   // To load the trackers and scripts
-  if (getCookieValue('consentAction') === 'accept') {
-    loadScripts(window, document, 'script', 'dataLayer', gtmCode);
+  if (getCookieValue("consentAction") === "accept") {
+    loadScripts();
   }
 
   // Listeners
   if (rejectButton) {
-    rejectButton.addEventListener('click', function(e) {
+    rejectButton.addEventListener("click", function (e) {
       closeConsentBanner();
       sendClickAction(e.target.id);
     });
   }
 
   if (acceptButton) {
-    acceptButton.addEventListener('click', function(e) {
+    acceptButton.addEventListener("click", function (e) {
       closeConsentBanner();
-      loadScripts(window, document, 'script', 'dataLayer', gtmCode);
+      loadScripts();
       sendClickAction(e.target.id);
+      options.onAccept && options.onAccept();
     });
   }
 
   if (cookieOverlay) {
-    cookieOverlay.addEventListener("click", function(e) {
+    cookieOverlay.addEventListener("click", function (e) {
       closeConsentBanner();
       sendClickAction(e.target.id);
     });
   }
 
   if (closeButton) {
-    closeButton.addEventListener("click", function(e) {
+    closeButton.addEventListener("click", function (e) {
       closeConsentBanner();
       sendClickAction(e.target.id);
     });
   }
 
   if (consentBanner) {
-    consentBanner.addEventListener("keydown", function(e) {
+    consentBanner.addEventListener("keydown", function (e) {
       switch (e.key) {
         case "Tab":
           if (e.shiftKey) {
@@ -267,4 +318,4 @@ window.BarnardosConsent = function(options) {
       }
     });
   }
-};
+}

--- a/consent-banner.es5.js
+++ b/consent-banner.es5.js
@@ -62,6 +62,7 @@ function barnardosCustomConsent(options) {
 
   // Build a button
   var buildButton = function (text) {
+    const content = arguments[1];
     var button = document.createElement(options.buttonElement);
     switch (options.buttonElement) {
       case "button":
@@ -70,15 +71,15 @@ function barnardosCustomConsent(options) {
         button.setAttribute("href", "#");
     }
     button.id = text.toLowerCase();
-    button.textContent = text;
+    button.innerHTML = text + (content || "");
     button.className = options.buttonClass;
     return button;
   };
 
   // Create the two buttons and a placeholder for the banner
   var consentBanner = document.createElement("div");
-  var rejectButton = buildButton("Reject");
-  var acceptButton = buildButton("Accept");
+  var rejectButton = buildButton("Reject", options.buttonContent);
+  var acceptButton = buildButton("Accept", options.buttonContent);
   var cookieOverlay = document.createElement("div");
   var closeButton = document.createElement(options.closeButtonElement);
   if (options.buttonElement == "a") {

--- a/consent-banner.es5.js
+++ b/consent-banner.es5.js
@@ -2,7 +2,7 @@
 //common options routines
 function set_static_defaults(options, defaults) {
   Object.keys(defaults).forEach((key) => {
-    options[key] = options[key] || defaults[key];
+    options[key] = options.hasOwnProperty(key) ? options[key] : defaults[key];
   });
   return options;
 }
@@ -49,6 +49,7 @@ function barnardosCustomConsent(options) {
     closeButtonContent: "&#x2715;",
     closeButtonClass: "_barnardos-cookie-close",
     closeButtonElement: "button",
+    restrictDomain: ".barnardos.org.uk",
   });
 
   var scripts = options.additionalScripts;
@@ -58,6 +59,20 @@ function barnardosCustomConsent(options) {
       "(^|[^;]+)\\s*" + name + "\\s*=\\s*([^;]+)",
     );
     return result ? result.pop() : "";
+  };
+
+  var setCookieValue = function (name, value) {
+    var days = arguments[2] || 365;
+    var expires = new Date();
+    expires.setDate(expires.getDate() + days);
+    document.cookie =
+      name +
+      "=" +
+      value +
+      "; expires=" +
+      expires +
+      (options.restrictDomain ? ";domain=" + options.restrictDomain : "") +
+      "; path=/; SameSite=Strict";
   };
 
   // Build a button
@@ -136,12 +151,7 @@ function barnardosCustomConsent(options) {
   var closeConsentBanner = function () {
     consentBanner.parentNode.removeChild(consentBanner);
     cookieOverlay.parentNode.removeChild(cookieOverlay);
-    var expires = new Date();
-    expires.setDate(expires.getDate() + 365);
-    document.cookie =
-      "consentBanner=closed; expires=" +
-      expires +
-      ";domain=.barnardos.org.uk; path=/; SameSite=Strict";
+    setCookieValue("consentBanner", "closed");
   };
 
   // Load the scripts and trackers
@@ -174,12 +184,7 @@ function barnardosCustomConsent(options) {
     });
     // Add acceptance to cookie so we can load the
     // Trackers and scripts with subsequent page views
-    var expires = new Date();
-    expires.setDate(expires.getDate() + 365);
-    document.cookie =
-      "consentAction=accept; expires=" +
-      expires +
-      ";domain=.barnardos.org.uk; path=/; SameSite=Strict";
+    setCookieValue("consentAction", "accept");
   };
 
   // Create a YYYY-MM date format

--- a/consent-banner.es5.js
+++ b/consent-banner.es5.js
@@ -48,6 +48,7 @@ function barnardosCustomConsent(options) {
     buttonElement: "button",
     closeButtonContent: "&#x2715;",
     closeButtonClass: "_barnardos-cookie-close",
+    closeButtonElement: "button",
   });
 
   var scripts = options.additionalScripts;
@@ -79,7 +80,7 @@ function barnardosCustomConsent(options) {
   var rejectButton = buildButton("Reject");
   var acceptButton = buildButton("Accept");
   var cookieOverlay = document.createElement("div");
-  var closeButton = document.createElement(options.buttonElement);
+  var closeButton = document.createElement(options.closeButtonElement);
   if (options.buttonElement == "a") {
     closeButton.setAttribute("href", "#");
   }

--- a/consent-banner.es5.js
+++ b/consent-banner.es5.js
@@ -1,19 +1,24 @@
 "use strict";
+//common options routines
+function set_static_defaults(options, defaults) {
+  Object.keys(defaults).forEach((key) => {
+    options[key] = options[key] || defaults[key];
+  });
+  return options;
+}
+
 // Compatibility function, use this as entry point
 // if Barnardos banner default content is required
 window.BarnardosConsent = function (options) {
   if (!options.gtmCode) {
     return;
   }
-  var static_defaults = {
+  set_static_defaults(options, {
     privacyURL: "https://www.barnardos.org.uk/privacy-notice",
     cookieURL: "https://www.barnardos.org.uk/cookie-notice",
     bannerHeading: "Cookie tracking preference",
     styleContent:
       "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}",
-  };
-  Object.keys(static_defaults).forEach((key) => {
-    options[key] = options[key] || static_defaults[key];
   });
   //dynamic defaults
   options.bannerContent =
@@ -24,32 +29,25 @@ window.BarnardosConsent = function (options) {
 
 // new entry point without Barnardos default content
 function barnardosCustomConsent(options) {
-  var missingMandatoryOptions = "missing mandatory options";
-  "bannerHeading bannerContent"
-    .split(" ")
-    .forEach(
-      (option) =>
-        (missingMandatoryOptions += options[option] ? "" : `, ${option}`),
-    );
-
-  missingMandatoryOptions +=
-    options.useExternalStylesheet || options.styleContent
+  const missingMandatoryOptions =
+    "bannerHeading bannerContent"
+      .split(" ")
+      .map((option) => (options[option] ? "" : option))
+      .filter((option) => option.length)
+      .join(",") + (options.useExternalStylesheet || options.styleContent)
       ? ""
       : ",styleContent";
 
-  if (missingMandatoryOptions != "missing mandatory options") {
-    console.warn(missingMandatoryOptions);
+  if (missingMandatoryOptions.length) {
+    console.warn("missing mandatory options:", missingMandatoryOptions);
     return;
   }
 
-  var static_defaults = {
+  set_static_defaults(options, {
     buttonClass: "_barnardos-consent-banner__button",
     buttonElement: "button",
     closeButtonContent: "&#x2715;",
     closeButtonClass: "_barnardos-cookie-close",
-  };
-  Object.keys(static_defaults).forEach((key) => {
-    options[key] = options[key] || static_defaults[key];
   });
 
   var scripts = options.additionalScripts;

--- a/consent-banner.esm.js
+++ b/consent-banner.esm.js
@@ -23,7 +23,7 @@ const set_static_defaults = (options, defaults) => {
 
 // Compatibility function, use this as entry point
 // if Barnardos banner default content is required
-const barnardosConsent = (options) => {
+export const barnardosConsent = (options) => {
   const gtmCode = options.check(gtmCode);
   if (!gtmCode) {
     return;
@@ -43,7 +43,7 @@ const barnardosConsent = (options) => {
 };
 
 // new entry point without Barnardos default content
-const barnardosCustomConsent = (options) => {
+export const barnardosCustomConsent = (options) => {
   const missingMandatoryOptions =
     "bannerHeading bannerContent"
       .split(" ")
@@ -268,5 +268,4 @@ const barnardosCustomConsent = (options) => {
   }
 };
 
-barnardosConsent.custom = barnardosCustomConsent;
-module.exports = barnardosConsent;
+export default barnardosConsent;

--- a/consent-banner.esm.js
+++ b/consent-banner.esm.js
@@ -62,6 +62,7 @@ export const barnardosCustomConsent = (options) => {
     buttonElement: "button",
     closeButtonContent: "&#x2715;",
     closeButtonClass: "_barnardos-cookie-close",
+    closeButtonElement: "button",
   });
 
   let scripts = check(options, "additionalScripts");

--- a/consent-banner.esm.js
+++ b/consent-banner.esm.js
@@ -5,7 +5,8 @@ function check(options) {
   while ((key = arguments[i])) {
     const hit =
       options[key] ||
-      process.env[key.replace(/(a-z)([A-Z])/g, "$1_$2").toUpperCase()];
+      (process &&
+        process.env[key.replace(/(a-z)([A-Z])/g, "$1_$2").toUpperCase()]);
     if (hit) {
       return hit;
     }
@@ -94,7 +95,7 @@ export const barnardosCustomConsent = (options) => {
   const rejectButton = buildButton("Reject");
   const acceptButton = buildButton("Accept");
   const cookieOverlay = document.createElement("div");
-  const closeButton = document.createElement(options.buttonElement);
+  const closeButton = document.createElement(options.closeButtonElement);
   if (options.buttonElement == "a") {
     closeButton.setAttribute("href", "#");
   }

--- a/consent-banner.esm.js
+++ b/consent-banner.esm.js
@@ -24,7 +24,7 @@ const set_static_defaults = (options, defaults) => {
 // Compatibility function, use this as entry point
 // if Barnardos banner default content is required
 export const barnardosConsent = (options) => {
-  const gtmCode = options.check(gtmCode);
+  const gtmCode = check(options, "gtmCode");
   if (!gtmCode) {
     return;
   }

--- a/consent-banner.esm.js
+++ b/consent-banner.esm.js
@@ -5,8 +5,9 @@ function check(options) {
   while ((key = arguments[i])) {
     const hit =
       options[key] ||
-      (process &&
-        process.env[key.replace(/(a-z)([A-Z])/g, "$1_$2").toUpperCase()]);
+      (typeof process === "undefined"
+        ? null
+        : process.env[key.replace(/(a-z)([A-Z])/g, "$1_$2").toUpperCase()]);
     if (hit) {
       return hit;
     }

--- a/consent-banner.esm.js
+++ b/consent-banner.esm.js
@@ -77,7 +77,8 @@ export const barnardosCustomConsent = (options) => {
   };
 
   // Build a button
-  const buildButton = (text) => {
+  const buildButton = function (text) {
+    const content = arguments[1];
     const button = document.createElement(options.buttonElement);
     switch (options.buttonElement) {
       case "button":
@@ -86,15 +87,15 @@ export const barnardosCustomConsent = (options) => {
         button.setAttribute("href", "#");
     }
     button.id = text.toLowerCase();
-    button.textContent = text;
+    button.innerHTML = text + (content || "");
     button.className = options.buttonClass;
     return button;
   };
 
   // Create the two buttons and a placeholder for the banner
   const consentBanner = document.createElement("div");
-  const rejectButton = buildButton("Reject");
-  const acceptButton = buildButton("Accept");
+  var rejectButton = buildButton("Reject", options.buttonContent);
+  var acceptButton = buildButton("Accept", options.buttonContent);
   const cookieOverlay = document.createElement("div");
   const closeButton = document.createElement(options.closeButtonElement);
   if (options.buttonElement == "a") {

--- a/consent-banner.esm.js
+++ b/consent-banner.esm.js
@@ -1,5 +1,5 @@
 //common options routines
-const check = (options) => {
+function check(options) {
   let i = 1,
     key;
   while ((key = arguments[i])) {
@@ -12,7 +12,7 @@ const check = (options) => {
     i++;
   }
   return null;
-};
+}
 
 const set_static_defaults = (options, defaults) => {
   Object.keys(defaults).forEach((key) => {

--- a/consent-banner.esm.js
+++ b/consent-banner.esm.js
@@ -1,76 +1,131 @@
-export default () => {
+//common options routines
+const check = (options) => {
+  let i = 1,
+    key;
+  while ((key = arguments[i])) {
+    const hit =
+      options[key] ||
+      process.env[key.replace(/(a-z)([A-Z])/g, "$1_$2").toUpperCase()];
+    if (hit) {
+      return hit;
+    }
+    i++;
+  }
+  return null;
+};
 
-  const gtmCode = process.env.GTM_CODE;
+const set_static_defaults = (options, defaults) => {
+  Object.keys(defaults).forEach((key) => {
+    options[key] = check(options, key) || defaults[key];
+  });
+  return options;
+};
+
+// Compatibility function, use this as entry point
+// if Barnardos banner default content is required
+const barnardosConsent = (options) => {
+  const gtmCode = options.check(gtmCode);
   if (!gtmCode) {
     return;
   }
+  set_static_defaults(options, {
+    privacyURL: "https://www.barnardos.org.uk/privacy-notice",
+    cookieURL: "https://www.barnardos.org.uk/cookie-notice",
+    bannerHeading: "Cookie tracking preference",
+    styleContent:
+      "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}",
+  });
+  //dynamic defaults
+  options.bannerContent =
+    check(options, bannerContent) ||
+    `We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="${options.privacyURL}">privacy policy</a> and <a href="${options.cookieURL}">cookie notice</a> for more details.`;
+  barnardosCustomConsent(options);
+};
 
-  let privacyURL; 
-  let cookieURL;
-
-  if(process.env.PRIVACY_URL) {
-    privacyURL = options.privacyURL;
-  } else {
-    privacyURL = 'https://www.barnardos.org.uk/privacy-notice';
-  } 
-
-  if(process.env.COOKIE_URL) {
-    cookieURL = options.cookieURL;
-  } else {
-    cookieURL = 'https://www.barnardos.org.uk/cookie-notice';
+// new entry point without Barnardos default content
+const barnardosCustomConsent = (options) => {
+  const missingMandatoryOptions =
+    "bannerHeading bannerContent"
+      .split(" ")
+      .map((option) => (check(options, option) ? "" : option))
+      .filter((option) => option.length)
+      .join(",") + check(options, "useExternalStylesheet", "styleContent")
+      ? ""
+      : ",styleContent";
+  if (missingMandatoryOptions.length) {
+    console.warn("missing mandatory options:", missingMandatoryOptions);
+    return;
   }
+
+  set_static_defaults(options, {
+    buttonClass: "_barnardos-consent-banner__button",
+    buttonElement: "button",
+    closeButtonContent: "&#x2715;",
+    closeButtonClass: "_barnardos-cookie-close",
+  });
+
+  let scripts = check(options, "additionalScripts");
 
   const getCookieValue = (name) => {
     const result = document.cookie.match(
       `(^|[^;]+)\\s*${name}\\s*=\\s*([^;]+)`,
     );
-    return result ? result.pop() : '';
+    return result ? result.pop() : "";
   };
 
   // Build a button
   const buildButton = (text) => {
-    const button = document.createElement('button');
-    button.type = 'button';
+    const button = document.createElement(options.buttonElement);
+    switch (options.buttonElement) {
+      case "button":
+        button.type = "button";
+      case "a":
+        button.setAttribute("href", "#");
+    }
     button.id = text.toLowerCase();
     button.textContent = text;
-    button.className = '_barnardos-consent-banner__button';
+    button.className = options.buttonClass;
     return button;
   };
 
   // Create the two buttons and a placeholder for the banner
-  const consentBanner = document.createElement('div');
-  const rejectButton = buildButton('Reject');
-  const acceptButton = buildButton('Accept');
+  const consentBanner = document.createElement("div");
+  const rejectButton = buildButton("Reject");
+  const acceptButton = buildButton("Accept");
   const cookieOverlay = document.createElement("div");
-  const closeButton = document.createElement("button");
-
+  const closeButton = document.createElement(options.buttonElement);
+  if (options.buttonElement == "a") {
+    closeButton.setAttribute("href", "#");
+  }
   // Build the banner
   const buildBanner = () => {
     cookieOverlay.className = "_barnardos-cookie-overlay";
     cookieOverlay.id = "overlay";
-    consentBanner.className = '_barnardos-consent-banner';
+    consentBanner.className = "_barnardos-consent-banner";
     consentBanner.setAttribute("role", "dialog");
     consentBanner.setAttribute("aria-modal", "true");
     consentBanner.setAttribute("aria-labelledby", "dialog-title");
     consentBanner.setAttribute("aria-describedby", "dialog-description");
     consentBanner.setAttribute("tabindex", "-1");
     closeButton.id = "close";
-    closeButton.className = "_barnardos-cookie-close";
+    closeButton.className = options.closeButtonClass;
     closeButton.setAttribute("aria-label", "Close cookie tracking preference");
-    closeButton.innerHTML = "&#x2715;";
+    closeButton.innerHTML = options.closeButtonContent;
     const heading = document.createElement("h2");
-    heading.textContent = "Cookie tracking preference";
+    heading.textContent = options.bannerHeading;
     heading.className = "_barnardos-cookie-heading";
     heading.id = "dialog-title";
-    const text = document.createElement('p');
+    const text = document.createElement("p");
     text.id = "dialog-description";
-    text.innerHTML = `We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="${privacyURL}">privacy policy</a> and <a href="${cookieURL}">cookie notice</a> for more details.`;
-    const style = document.createElement('style');
-    style.textContent = "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}";
-    consentBanner.appendChild(style);
+    text.innerHTML = options.bannerContent;
+    if (!options.useExternalStylesheet) {
+      const style = document.createElement("style");
+      style.textContent = options.styleContent;
+      consentBanner.appendChild(style);
+    }
     consentBanner.appendChild(heading);
     consentBanner.appendChild(text);
-    const buttonWrap = document.createElement('div');
+    const buttonWrap = document.createElement("div");
     buttonWrap.appendChild(rejectButton);
     buttonWrap.appendChild(acceptButton);
     consentBanner.appendChild(buttonWrap);
@@ -98,19 +153,34 @@ export default () => {
   };
 
   // Load the scripts and trackers
-  // Using the minified code GTM gives us
-  const loadScripts = (w, d, s, l, i) => {
-    w[l] = w[l] || [];
-    w[l].push({
-      'gtm.start': new Date().getTime(),
-      event: 'gtm.js',
+  options.gtmCode &&
+    (scripts = scripts || []).push({
+      // GTM script using the minified code GTM gives us
+      name: "GTM",
+      script: (w, d, s, l, i) => {
+        w[l] = w[l] || [];
+        w[l].push({
+          "gtm.start": new Date().getTime(),
+          event: "gtm.js",
+        });
+        const f = d.getElementsByTagName(s)[0];
+        const j = d.createElement(s);
+        const dl = l != "dataLayer" ? `&l=${l}` : "";
+        j.async = true;
+        j.src = `https://www.googletagmanager.com/gtm.js?id=${i}${dl}`;
+        f.parentNode.insertBefore(j, f);
+      },
+      args: [window, document, "script", "dataLayer", options.gtmCode],
     });
-    const f = d.getElementsByTagName(s)[0];
-    const j = d.createElement(s);
-    const dl = l != 'dataLayer' ? `&l=${l}` : '';
-    j.async = true;
-    j.src = `https://www.googletagmanager.com/gtm.js?id=${i}${dl}`;
-    f.parentNode.insertBefore(j, f);
+  if (!scripts) {
+    return;
+  }
+
+  var loadScripts = function () {
+    scripts.forEach(function (script) {
+      script.script(...script.args);
+    });
+
     // Add acceptance to cookie so we can load the trackers and scripts with subsequent page views
     const expires = new Date();
     expires.setDate(expires.getDate() + 365);
@@ -121,25 +191,25 @@ export default () => {
   const formatDate = (timestamp) => {
     const date = new Date(timestamp * 1000);
     const year = date.getFullYear();
-    const month = (`0${date.getMonth() + 1}`).slice(-2);
+    const month = `0${date.getMonth() + 1}`.slice(-2);
     return `${year}-${month}`;
   };
 
-  const handleForwardTab = function(e) {
+  const handleForwardTab = function (e) {
     if (document.activeElement === lastFocusableElement) {
       e.preventDefault();
       firstFocusableElement.focus();
     }
   };
 
-  const handleBackwardTab = function(e) {
+  const handleBackwardTab = function (e) {
     if (document.activeElement === firstFocusableElement) {
       e.preventDefault();
       lastFocusableElement.focus();
     }
   };
 
-  if (getCookieValue('consentBanner') !== 'closed') {
+  if (getCookieValue("consentBanner") !== "closed") {
     // Check if the banner has been loaded and if not send a session load to the counter
     if (sessionStorage.consentBannerSessionLoad !== "loaded") {
       sessionStorage.consentBannerSessionLoad = "loaded";
@@ -148,21 +218,21 @@ export default () => {
   }
 
   // If cookies are previously accepted run the function to load the trackers and scripts
-  if (getCookieValue('consentAction') === 'accept') {
-    loadScripts(window, document, 'script', 'dataLayer', gtmCode); // eslint-disable-line no-undef
+  if (getCookieValue("consentAction") === "accept") {
+    loadScripts();
   }
 
   // Listeners
   if (rejectButton) {
-    rejectButton.addEventListener('click', (e) => {
+    rejectButton.addEventListener("click", (e) => {
       closeConsentBanner();
     });
   }
 
   if (acceptButton) {
-    acceptButton.addEventListener('click', (e) => {
+    acceptButton.addEventListener("click", (e) => {
       closeConsentBanner();
-      loadScripts(window, document, 'script', 'dataLayer', gtmCode); // eslint-disable-line no-undef
+      loadScripts();
     });
   }
 
@@ -197,3 +267,6 @@ export default () => {
     });
   }
 };
+
+barnardosConsent.custom = barnardosCustomConsent;
+module.exports = barnardosConsent;

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -24,7 +24,7 @@ const set_static_defaults = (options, defaults) => {
 // Compatibility function, use this as entry point
 // if Barnardos banner default content is required
 const barnardosConsent = (options) => {
-  const gtmCode = options.check(gtmCode);
+  const gtmCode = check(options, "gtmCode");
   if (!gtmCode) {
     return;
   }

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -76,7 +76,8 @@ const barnardosCustomConsent = (options) => {
   };
 
   // Build a button
-  const buildButton = (text) => {
+  const buildButton = function (text) {
+    const content = arguments[1];
     const button = document.createElement(options.buttonElement);
     switch (options.buttonElement) {
       case "button":
@@ -85,15 +86,15 @@ const barnardosCustomConsent = (options) => {
         button.setAttribute("href", "#");
     }
     button.id = text.toLowerCase();
-    button.textContent = text;
+    button.innerHTML = text + (content || "");
     button.className = options.buttonClass;
     return button;
   };
 
   // Create the two buttons and a placeholder for the banner
   const consentBanner = document.createElement("div");
-  const rejectButton = buildButton("Reject");
-  const acceptButton = buildButton("Accept");
+  var rejectButton = buildButton("Reject", options.buttonContent);
+  var acceptButton = buildButton("Accept", options.buttonContent);
   const cookieOverlay = document.createElement("div");
   const closeButton = document.createElement(options.closeButtonElement);
   if (options.buttonElement == "a") {

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -1,9 +1,14 @@
 //common options routines
 const check = (options) => {
-  let i = 1, key;
-  while (key = arguments[i]) {
-    const hit = options[key] || process.env[key.replace(/(a-z)([A-Z])/g, '$1_$2').toUpperCase()];
-    if (hit) { return hit }
+  let i = 1,
+    key;
+  while ((key = arguments[i])) {
+    const hit =
+      options[key] ||
+      process.env[key.replace(/(a-z)([A-Z])/g, "$1_$2").toUpperCase()];
+    if (hit) {
+      return hit;
+    }
     i++;
   }
   return null;
@@ -14,11 +19,11 @@ const set_static_defaults = (options, defaults) => {
     options[key] = check(options, key) || defaults[key];
   });
   return options;
-}
+};
 
 // Compatibility function, use this as entry point
 // if Barnardos banner default content is required
-function barnardosConsent = (options) => {
+const barnardosConsent = (options) => {
   const gtmCode = options.check(gtmCode);
   if (!gtmCode) {
     return;
@@ -39,12 +44,14 @@ function barnardosConsent = (options) => {
 
 // new entry point without Barnardos default content
 const barnardosCustomConsent = (options) => {
-  const missingMandatoryOptions = "bannerHeading bannerContent"
-    .split(" ")
-    .map(option => check(options, option) ? "" : option)
-    .filter(option => option.length)
-    .join(",") +
-    check(options, "useExternalStylesheet", "styleContent") ? "" : ",styleContent";
+  const missingMandatoryOptions =
+    "bannerHeading bannerContent"
+      .split(" ")
+      .map((option) => (check(options, option) ? "" : option))
+      .filter((option) => option.length)
+      .join(",") + check(options, "useExternalStylesheet", "styleContent")
+      ? ""
+      : ",styleContent";
 
   if (missingMandatoryOptions.length) {
     console.warn("missing mandatory options:", missingMandatoryOptions);
@@ -58,13 +65,13 @@ const barnardosCustomConsent = (options) => {
     closeButtonClass: "_barnardos-cookie-close",
   });
 
-  let scripts = check(options, 'additionalScripts');
+  let scripts = check(options, "additionalScripts");
 
   const getCookieValue = (name) => {
     const result = document.cookie.match(
       `(^|[^;]+)\\s*${name}\\s*=\\s*([^;]+)`,
     );
-    return result ? result.pop() : '';
+    return result ? result.pop() : "";
   };
 
   // Build a button
@@ -83,9 +90,9 @@ const barnardosCustomConsent = (options) => {
   };
 
   // Create the two buttons and a placeholder for the banner
-  const consentBanner = document.createElement('div');
-  const rejectButton = buildButton('Reject');
-  const acceptButton = buildButton('Accept');
+  const consentBanner = document.createElement("div");
+  const rejectButton = buildButton("Reject");
+  const acceptButton = buildButton("Accept");
   const cookieOverlay = document.createElement("div");
   const closeButton = document.createElement(options.buttonElement);
   if (options.buttonElement == "a") {
@@ -95,7 +102,7 @@ const barnardosCustomConsent = (options) => {
   const buildBanner = () => {
     cookieOverlay.className = "_barnardos-cookie-overlay";
     cookieOverlay.id = "overlay";
-    consentBanner.className = '_barnardos-consent-banner';
+    consentBanner.className = "_barnardos-consent-banner";
     consentBanner.setAttribute("role", "dialog");
     consentBanner.setAttribute("aria-modal", "true");
     consentBanner.setAttribute("aria-labelledby", "dialog-title");
@@ -109,17 +116,17 @@ const barnardosCustomConsent = (options) => {
     heading.textContent = options.bannerHeading;
     heading.className = "_barnardos-cookie-heading";
     heading.id = "dialog-title";
-    const text = document.createElement('p');
+    const text = document.createElement("p");
     text.id = "dialog-description";
     text.innerHTML = options.bannerContent;
     if (!options.useExternalStylesheet) {
-      const style = document.createElement('style');
+      const style = document.createElement("style");
       style.textContent = options.styleContent;
       consentBanner.appendChild(style);
     }
     consentBanner.appendChild(heading);
     consentBanner.appendChild(text);
-    const buttonWrap = document.createElement('div');
+    const buttonWrap = document.createElement("div");
     buttonWrap.appendChild(rejectButton);
     buttonWrap.appendChild(acceptButton);
     consentBanner.appendChild(buttonWrap);
@@ -159,7 +166,7 @@ const barnardosCustomConsent = (options) => {
         });
         const f = d.getElementsByTagName(s)[0];
         const j = d.createElement(s);
-        const dl = l != 'dataLayer' ? `&l=${l}` : '';
+        const dl = l != "dataLayer" ? `&l=${l}` : "";
         j.async = true;
         j.src = `https://www.googletagmanager.com/gtm.js?id=${i}${dl}`;
         f.parentNode.insertBefore(j, f);
@@ -170,8 +177,8 @@ const barnardosCustomConsent = (options) => {
     return;
   }
 
-  var loadScripts = function() {
-    scripts.forEach(function(script) {
+  var loadScripts = function () {
+    scripts.forEach(function (script) {
       script.script(...script.args);
     });
 
@@ -185,25 +192,25 @@ const barnardosCustomConsent = (options) => {
   const formatDate = (timestamp) => {
     const date = new Date(timestamp * 1000);
     const year = date.getFullYear();
-    const month = (`0${date.getMonth() + 1}`).slice(-2);
+    const month = `0${date.getMonth() + 1}`.slice(-2);
     return `${year}-${month}`;
   };
 
-  const handleForwardTab = function(e) {
+  const handleForwardTab = function (e) {
     if (document.activeElement === lastFocusableElement) {
       e.preventDefault();
       firstFocusableElement.focus();
     }
   };
 
-  const handleBackwardTab = function(e) {
+  const handleBackwardTab = function (e) {
     if (document.activeElement === firstFocusableElement) {
       e.preventDefault();
       lastFocusableElement.focus();
     }
   };
 
-  if (getCookieValue('consentBanner') !== 'closed') {
+  if (getCookieValue("consentBanner") !== "closed") {
     // Check if the banner has been loaded and if not send a session load to the counter
     if (sessionStorage.consentBannerSessionLoad !== "loaded") {
       sessionStorage.consentBannerSessionLoad = "loaded";
@@ -212,19 +219,19 @@ const barnardosCustomConsent = (options) => {
   }
 
   // If cookies are previously accepted run the function to load the trackers and scripts
-  if (getCookieValue('consentAction') === 'accept') {
+  if (getCookieValue("consentAction") === "accept") {
     loadScripts();
   }
 
   // Listeners
   if (rejectButton) {
-    rejectButton.addEventListener('click', (e) => {
+    rejectButton.addEventListener("click", (e) => {
       closeConsentBanner();
     });
   }
 
   if (acceptButton) {
-    acceptButton.addEventListener('click', (e) => {
+    acceptButton.addEventListener("click", (e) => {
       closeConsentBanner();
       loadScripts();
     });

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -1,13 +1,17 @@
 //common options routines
 function check(options) {
   let i = 1,
+    found = {},
     key;
   while ((key = arguments[i])) {
-    const hit =
-      options[key] ||
-      process.env[key.replace(/(a-z)([A-Z])/g, "$1_$2").toUpperCase()];
-    if (hit) {
-      return hit;
+    const snakeCapsKey = key.replace(/([a-z])([A-Z])/g, "$1_$2").toUpperCase();
+    if (options.hasOwnProperty(key)) {
+      found[key] = options[key];
+      return found;
+    }
+    if (process.env.hasOwnProperty(snakeCapsKey)) {
+      found[key] = process.env[snakeCapsKey];
+      return found;
     }
     i++;
   }
@@ -16,7 +20,8 @@ function check(options) {
 
 const set_static_defaults = (options, defaults) => {
   Object.keys(defaults).forEach((key) => {
-    options[key] = check(options, key) || defaults[key];
+    const found = check(options, key);
+    options[key] = found ? found[key] : defaults[key];
   });
   return options;
 };
@@ -64,6 +69,7 @@ const barnardosCustomConsent = (options) => {
     closeButtonContent: "&#x2715;",
     closeButtonClass: "_barnardos-cookie-close",
     closeButtonElement: "button",
+    restrictDomain: ".barnardos.org.uk",
   });
 
   let scripts = check(options, "additionalScripts");
@@ -73,6 +79,20 @@ const barnardosCustomConsent = (options) => {
       `(^|[^;]+)\\s*${name}\\s*=\\s*([^;]+)`,
     );
     return result ? result.pop() : "";
+  };
+
+  const setCookieValue = function (name, value) {
+    var days = arguments[2] || 365;
+    var expires = new Date();
+    expires.setDate(expires.getDate() + days);
+    document.cookie =
+      name +
+      "=" +
+      value +
+      "; expires=" +
+      expires +
+      (options.restrictDomain ? ";domain=" + options.restrictDomain : "") +
+      "; path=/; SameSite=Strict";
   };
 
   // Build a button
@@ -150,9 +170,7 @@ const barnardosCustomConsent = (options) => {
   const closeConsentBanner = () => {
     consentBanner.parentNode.removeChild(consentBanner);
     cookieOverlay.parentNode.removeChild(cookieOverlay);
-    const expires = new Date();
-    expires.setDate(expires.getDate() + 365);
-    document.cookie = `consentBanner=closed; expires=${expires}; domain=.barnardos.org.uk; path=/; SameSite=Strict`;
+    setCookieValue("consentBanner", "closed");
   };
 
   // Load the scripts and trackers
@@ -185,9 +203,7 @@ const barnardosCustomConsent = (options) => {
     });
 
     // Add acceptance to cookie so we can load the trackers and scripts with subsequent page views
-    const expires = new Date();
-    expires.setDate(expires.getDate() + 365);
-    document.cookie = `consentAction=accept; expires=${expires}; domain=.barnardos.org.uk; path=/; SameSite=Strict`;
+    setCookieValue("consentAction", "accept");
   };
 
   // Create a YYYY-MM date format

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -1,5 +1,5 @@
 //common options routines
-const check = (options) => {
+function check(options) {
   let i = 1,
     key;
   while ((key = arguments[i])) {
@@ -12,7 +12,7 @@ const check = (options) => {
     i++;
   }
   return null;
-};
+}
 
 const set_static_defaults = (options, defaults) => {
   Object.keys(defaults).forEach((key) => {

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -1,24 +1,12 @@
-module.exports = () => {
+module.exports = (options) => {
 
   const gtmCode = process.env.GTM_CODE;
   if (!gtmCode) {
     return;
   }
 
-  let privacyURL; 
-  let cookieURL;
-
-  if(process.env.PRIVACY_URL) {
-    privacyURL = options.privacyURL;
-  } else {
-    privacyURL = 'https://www.barnardos.org.uk/privacy-notice';
-  } 
-
-  if(process.env.COOKIE_URL) {
-    cookieURL = options.cookieURL;
-  } else {
-    cookieURL = 'https://www.barnardos.org.uk/cookie-notice';
-  }
+  const privacyURL = options.privacyURL || process.env.PRIVACY_URL || 'https://www.barnardos.org.uk/privacy-notice';
+  const cookieURL = options.cookieURL || process.env.COOKIE_URL || 'https://www.barnardos.org.uk/cookie-notice';
 
   const getCookieValue = (name) => {
     const result = document.cookie.match(
@@ -59,15 +47,17 @@ module.exports = () => {
     closeButton.setAttribute("aria-label", "Close cookie tracking preference");
     closeButton.innerHTML = "&#x2715;";
     const heading = document.createElement("h2");
-    heading.textContent = "Cookie tracking preference";
+    heading.textContent = options.bannerHeading || "Cookie tracking preference";
     heading.className = "_barnardos-cookie-heading";
     heading.id = "dialog-title";
     const text = document.createElement('p');
     text.id = "dialog-description";
-    text.innerHTML = `We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="${privacyURL}">privacy policy</a> and <a href="${cookieURL}">cookie notice</a> for more details.`;
-    const style = document.createElement('style');
-    style.textContent = "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}";
-    consentBanner.appendChild(style);
+    text.innerHTML = options.bannerContent || `We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="${privacyURL}">privacy policy</a> and <a href="${cookieURL}">cookie notice</a> for more details.`;
+    if (!options.useExternalStylesheet) {
+      const style = document.createElement('style');
+      style.textContent = "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}";
+      consentBanner.appendChild(style);
+    }
     consentBanner.appendChild(heading);
     consentBanner.appendChild(text);
     const buttonWrap = document.createElement('div');

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -1,12 +1,64 @@
-module.exports = (options) => {
+//common options routines
+const check = (options) => {
+  let i = 1, key;
+  while (key = arguments[i]) {
+    const hit = options[key] || process.env[key.replace(/(a-z)([A-Z])/g, '$1_$2').toUpperCase()];
+    if (hit) { return hit }
+    i++;
+  }
+  return null;
+};
 
-  const gtmCode = process.env.GTM_CODE;
+const set_static_defaults = (options, defaults) => {
+  Object.keys(defaults).forEach((key) => {
+    options[key] = check(options, key) || defaults[key];
+  });
+  return options;
+}
+
+// Compatibility function, use this as entry point
+// if Barnardos banner default content is required
+function barnardosConsent = (options) => {
+  const gtmCode = options.check(gtmCode);
   if (!gtmCode) {
     return;
   }
+  set_static_defaults(options, {
+    privacyURL: "https://www.barnardos.org.uk/privacy-notice",
+    cookieURL: "https://www.barnardos.org.uk/cookie-notice",
+    bannerHeading: "Cookie tracking preference",
+    styleContent:
+      "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}",
+  });
+  //dynamic defaults
+  options.bannerContent =
+    check(options, bannerContent) ||
+    `We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="${options.privacyURL}">privacy policy</a> and <a href="${options.cookieURL}">cookie notice</a> for more details.`;
+  barnardosCustomConsent(options);
+};
 
-  const privacyURL = options.privacyURL || process.env.PRIVACY_URL || 'https://www.barnardos.org.uk/privacy-notice';
-  const cookieURL = options.cookieURL || process.env.COOKIE_URL || 'https://www.barnardos.org.uk/cookie-notice';
+// new entry point without Barnardos default content
+const barnardosCustomConsent = (options) => {
+  const missingMandatoryOptions = "bannerHeading bannerContent"
+    .split(" ")
+    .map(option => check(options, option) ? "" : option)
+    .filter(option => option.length)
+    .join(",") +
+    check(options, "useExternalStylesheet", "styleContent") ? "" : ",styleContent";
+
+  if (missingMandatoryOptions.length) {
+    console.warn("missing mandatory options:", missingMandatoryOptions);
+    return;
+  }
+
+  set_static_defaults(options, {
+    buttonClass: "_barnardos-consent-banner__button",
+    buttonElement: "button",
+    closeButtonContent: "&#x2715;",
+    closeButtonClass: "_barnardos-cookie-close",
+  });
+
+  let scripts = check(options, 'additionalScripts');
 
   const getCookieValue = (name) => {
     const result = document.cookie.match(
@@ -17,11 +69,16 @@ module.exports = (options) => {
 
   // Build a button
   const buildButton = (text) => {
-    const button = document.createElement('button');
-    button.type = 'button';
+    const button = document.createElement(options.buttonElement);
+    switch (options.buttonElement) {
+      case "button":
+        button.type = "button";
+      case "a":
+        button.setAttribute("href", "#");
+    }
     button.id = text.toLowerCase();
     button.textContent = text;
-    button.className = '_barnardos-consent-banner__button';
+    button.className = options.buttonClass;
     return button;
   };
 
@@ -30,8 +87,10 @@ module.exports = (options) => {
   const rejectButton = buildButton('Reject');
   const acceptButton = buildButton('Accept');
   const cookieOverlay = document.createElement("div");
-  const closeButton = document.createElement("button");
-
+  const closeButton = document.createElement(options.buttonElement);
+  if (options.buttonElement == "a") {
+    closeButton.setAttribute("href", "#");
+  }
   // Build the banner
   const buildBanner = () => {
     cookieOverlay.className = "_barnardos-cookie-overlay";
@@ -43,19 +102,19 @@ module.exports = (options) => {
     consentBanner.setAttribute("aria-describedby", "dialog-description");
     consentBanner.setAttribute("tabindex", "-1");
     closeButton.id = "close";
-    closeButton.className = "_barnardos-cookie-close";
+    closeButton.className = options.closeButtonClass;
     closeButton.setAttribute("aria-label", "Close cookie tracking preference");
-    closeButton.innerHTML = "&#x2715;";
+    closeButton.innerHTML = options.closeButtonContent;
     const heading = document.createElement("h2");
-    heading.textContent = options.bannerHeading || "Cookie tracking preference";
+    heading.textContent = options.bannerHeading;
     heading.className = "_barnardos-cookie-heading";
     heading.id = "dialog-title";
     const text = document.createElement('p');
     text.id = "dialog-description";
-    text.innerHTML = options.bannerContent || `We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="${privacyURL}">privacy policy</a> and <a href="${cookieURL}">cookie notice</a> for more details.`;
+    text.innerHTML = options.bannerContent;
     if (!options.useExternalStylesheet) {
       const style = document.createElement('style');
-      style.textContent = "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}";
+      style.textContent = options.styleContent;
       consentBanner.appendChild(style);
     }
     consentBanner.appendChild(heading);
@@ -88,19 +147,34 @@ module.exports = (options) => {
   };
 
   // Load the scripts and trackers
-  // Using the minified code GTM gives us
-  const loadScripts = (w, d, s, l, i) => {
-    w[l] = w[l] || [];
-    w[l].push({
-      'gtm.start': new Date().getTime(),
-      event: 'gtm.js',
+  options.gtmCode &&
+    (scripts = scripts || []).push({
+      // GTM script using the minified code GTM gives us
+      name: "GTM",
+      script: (w, d, s, l, i) => {
+        w[l] = w[l] || [];
+        w[l].push({
+          "gtm.start": new Date().getTime(),
+          event: "gtm.js",
+        });
+        const f = d.getElementsByTagName(s)[0];
+        const j = d.createElement(s);
+        const dl = l != 'dataLayer' ? `&l=${l}` : '';
+        j.async = true;
+        j.src = `https://www.googletagmanager.com/gtm.js?id=${i}${dl}`;
+        f.parentNode.insertBefore(j, f);
+      },
+      args: [window, document, "script", "dataLayer", options.gtmCode],
     });
-    const f = d.getElementsByTagName(s)[0];
-    const j = d.createElement(s);
-    const dl = l != 'dataLayer' ? `&l=${l}` : '';
-    j.async = true;
-    j.src = `https://www.googletagmanager.com/gtm.js?id=${i}${dl}`;
-    f.parentNode.insertBefore(j, f);
+  if (!scripts) {
+    return;
+  }
+
+  var loadScripts = function() {
+    scripts.forEach(function(script) {
+      script.script(...script.args);
+    });
+
     // Add acceptance to cookie so we can load the trackers and scripts with subsequent page views
     const expires = new Date();
     expires.setDate(expires.getDate() + 365);
@@ -139,7 +213,7 @@ module.exports = (options) => {
 
   // If cookies are previously accepted run the function to load the trackers and scripts
   if (getCookieValue('consentAction') === 'accept') {
-    loadScripts(window, document, 'script', 'dataLayer', gtmCode); // eslint-disable-line no-undef
+    loadScripts();
   }
 
   // Listeners
@@ -152,7 +226,7 @@ module.exports = (options) => {
   if (acceptButton) {
     acceptButton.addEventListener('click', (e) => {
       closeConsentBanner();
-      loadScripts(window, document, 'script', 'dataLayer', gtmCode); // eslint-disable-line no-undef
+      loadScripts();
     });
   }
 
@@ -187,3 +261,6 @@ module.exports = (options) => {
     });
   }
 };
+
+barnardosConsent.custom = barnardosCustomConsent;
+module.exports = barnardosConsent;

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -63,6 +63,7 @@ const barnardosCustomConsent = (options) => {
     buttonElement: "button",
     closeButtonContent: "&#x2715;",
     closeButtonClass: "_barnardos-cookie-close",
+    closeButtonElement: "button",
   });
 
   let scripts = check(options, "additionalScripts");
@@ -94,7 +95,7 @@ const barnardosCustomConsent = (options) => {
   const rejectButton = buildButton("Reject");
   const acceptButton = buildButton("Accept");
   const cookieOverlay = document.createElement("div");
-  const closeButton = document.createElement(options.buttonElement);
+  const closeButton = document.createElement(options.closeButtonElement);
   if (options.buttonElement == "a") {
     closeButton.setAttribute("href", "#");
   }

--- a/consent-banner.template.css
+++ b/consent-banner.template.css
@@ -1,0 +1,80 @@
+._barnardos-cookie-overlay {
+  z-index: 3;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+}
+._barnardos-consent-banner {
+  background-color: #fff;
+  padding: 0.5rem 1rem 1rem;
+  position: fixed;
+  top: 10%;
+  right: 5%;
+  bottom: 10%;
+  left: 5%;
+  z-index: 4;
+  overflow-y: scroll;
+}
+@media screen and (min-width: 360px) and (min-height: 600px) {
+  ._barnardos-consent-banner {
+    top: 50%;
+    left: 50%;
+    bottom: 30%;
+    width: 90%;
+    max-width: 36rem;
+    transform: translate(-50%, -50%);
+    bottom: auto;
+  }
+}
+._barnardos-consent-banner:focus {
+  outline: none;
+}
+._barnardos-consent-banner h2 {
+  margin-right: 2rem;
+}
+._barnardos-consent-banner p {
+  display: inline-block;
+  margin: 0.5rem 0 1.5rem;
+  vertical-align: middle;
+}
+._barnardos-consent-banner div {
+  display: inline-block;
+  white-space: nowrap;
+}
+._barnardos-consent-banner button {
+  appearance: none;
+  background-color: #558200;
+  border: 1px solid #558200;
+  border-radius: 0;
+  color: #fff;
+  display: inline-block;
+  font-size: 1.125rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  padding: 0.5rem 2rem;
+  text-align: center;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  margin: 0 1em 0 0;
+}
+._barnardos-consent-banner button:hover,
+._barnardos-consent-banner button:focus {
+  background-color: #192700;
+  border-color: #192700;
+}
+._barnardos-consent-banner a {
+  text-decoration: underline;
+}
+._barnardos-consent-banner ._barnardos-cookie-close {
+  position: absolute;
+  right: 0;
+  top: 0;
+  margin: 0;
+  line-height: 1;
+  padding: 0.5rem;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barnardos/customisable-consent-banner",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barnardos/customisable-consent-banner",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barnardos/customisable-consent-banner",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barnardos/customisable-consent-banner",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@barnardoswebteam/customisable-consent-banner",
+  "name": "@barnardos/customisable-consent-banner",
   "version": "0.1.0",
   "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@barnardoswebteam/consent-banner",
-  "version": "0.4.3",
-  "description": "Barnardo's consent banner.",
+  "name": "@barnardoswebteam/customisable-consent-banner",
+  "version": "0.1.0",
+  "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -10,18 +10,13 @@
     "type": "git",
     "url": "git+https://github.com/barnardos/consent-banner.git"
   },
-  "keywords": [
-    "barnardos",
-    "cookies",
-    "consent",
-    "banner"
-  ],
-  "author": "Barnardo's Web Team <websiteteam@barnardos.org.uk> (https://www.barnardos.org.uk)",
+  "keywords": ["barnardos", "customisable", "cookies", "consent", "banner"],
+  "author": "Barnardo's Innovation Lab Team<InnovationLabTeam@barnardos.org.uk> (https://www.barnardos.org.uk)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/barnardos/consent-banner/issues"
+    "url": "https://github.com/barnardos/customisable-consent-banner/issues"
   },
-  "homepage": "https://github.com/barnardos/consent-banner#readme",
+  "homepage": "https://github.com/barnardos/customisable-consent-banner#readme",
   "devDependencies": {
     "eslint": "^7.25.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barnardos/customisable-consent-banner",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "@barnardos/customisable-consent-banner",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "type": "module",
+  "module": "consent-banner.esm.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/barnardos/consent-banner.git"
+    "url": "git+https://github.com/barnardos/customisable-consent-banner.git"
   },
   "keywords": ["barnardos", "customisable", "cookies", "consent", "banner"],
   "author": "Barnardo's Innovation Lab Team<InnovationLabTeam@barnardos.org.uk> (https://www.barnardos.org.uk)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barnardos/customisable-consent-banner",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",
   "scripts": {


### PR DESCRIPTION
old Barnardos defaults are now accessed via a compatibility entry point
new entry point allows fully customisable:
	•	banner heading,
	•	banner content text,
	•	close button,
	•	accept/reject button icons,
	•	styling (or use of external stylesheet),
	•	scripts to load if the cookie is accepted
	•	optional force reload once accept button pressed