### PR TITLE
Switch to using '*' instead of false to mean no domain restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Run `npm install @barnardoswebteam/customisable-consent-banner` or `yarn add @ba
 For the standard consent banner, in your code add the following:
 
 ```js
-const consentBanner = require('@barnardoswebteam/consent-banner');
+const consentBanner = require("@barnardoswebteam/consent-banner");
 consentBanner();
 ```
 
@@ -23,17 +23,17 @@ You can customise the standard consent banner by passing options, either in .env
 - BANNER_CONTENT: Custom text content (but not buttons)
 - CLOSE_BUTTON_CONTENT: Custom text or an svg for the close button. Defaults to "&#x2715;".
 - ADDITIONAL_SCRIPTS: An array of additional tracking scripts to be ran when the consent banner is accepted. If you have other scripts to use instead, GTM_CODE is optional and omitting it will prevent the banner attempting to load GTM scripts. Scripts are described by JSON objects with the properties name (arbitrary, for your reference), script (a function to execute), and args (an array of arguments to pass when the script is accepted). Defaults to none.
-- RESTRICT_DOMAIN: defaults to ```'.barnardos.org.uk'``` but you can use this to set another domain or if set to ```false``` it will allow the banner to be shown on any domain.
-- RELOAD_ON_ACCEPT: set this to ```true``` to set the cookie and then reload the page if you have scripts which cannot be provided above for architectural reasons, and which have loaded with defaults that cannot be easily toggled at run time. Defaults to ```false```.
-- STYLE_CONTENT: Custom styles for the consent banner. Defaults to those outlined in ```consent-banner.template.css``` in the package. You can copy this template to help you customise the styles.
+- RESTRICT_DOMAIN: defaults to `'.barnardos.org.uk'` but you can use this to set another domain, or if set to the string `*` it will allow the banner to be shown on any domain.
+- RELOAD_ON_ACCEPT: set this to `true` to set the cookie and then reload the page if you have scripts which cannot be provided above for architectural reasons, and which have loaded with defaults that cannot be easily toggled at run time. Defaults to `false`.
+- STYLE_CONTENT: Custom styles for the consent banner. Defaults to those outlined in `consent-banner.template.css` in the package. You can copy this template to help you customise the styles.
 - USE_EXTERNAL_STYLESHEET: use this instead of STYLE_CONTENT to link to an external stylesheet provied by your application. You can copy the template above to your own stylesheet to help you customise the styles.
 - BUTTON_ELEMENT: If you are using your own stylesheet you may prefer to use a different element for the accept/reject buttons. Defaults to "button".
 - BUTTON_CONTENT: Use this to add HTML content such as an SVG icon after the Accept/Reject button text. Defaults to none.
-- BUTTON_CLASS: If you are using your own stylesheet you may prefer your own class name for the button styling. Defaults to "_barnardos-consent-banner__button".
+- BUTTON_CLASS: If you are using your own stylesheet you may prefer your own class name for the button styling. Defaults to "\_barnardos-consent-banner\_\_button".
 - CLOSE_BUTTON_ELEMENT: If you are using your own stylesheet you may prefer to use a different element for the close button. Defaults to "button".
-- CLOSE_BUTTON_CLASS: If you are using your own stylesheet you may prefer your own class name for the close button styling. Defaults to "_barnardos-cookie-close".
+- CLOSE_BUTTON_CLASS: If you are using your own stylesheet you may prefer your own class name for the close button styling. Defaults to "\_barnardos-cookie-close".
 
-If you have extensively customised the styles and the banner content, you can reduce the size of your JavaScript by bypassing the ```ConsentBanner``` wrapper (```barnardosConsent``` if using es5) and calling ```ConsentBanner.Custom``` (or ```barnardosCustomConsent``` if using es5) directly to avoid loading the redundant default styles and content.
+If you have extensively customised the styles and the banner content, you can reduce the size of your JavaScript by bypassing the `ConsentBanner` wrapper (`barnardosConsent` if using es5) and calling `ConsentBanner.Custom` (or `barnardosCustomConsent` if using es5) directly to avoid loading the redundant default styles and content.
 
 ### Option 2: <abbr title="ECMAScript Module">ESM</a>
 
@@ -42,10 +42,11 @@ For the standard consent banner, in your HTML add the following:
 ```html
 <script type="module" src="main.js"></script>
 ```
+
 and in main.js:
 
 ```js
-import consentBanner from './path/to/consent-banner.esm.js';
+import consentBanner from "./path/to/consent-banner.esm.js";
 consentBanner();
 ```
 
@@ -59,15 +60,19 @@ For the standard consent banner, put the following near the end of the body elem
 
 ```html
 <script src="path/to/consent-banner.es5.js"></script>
-<script>BarnardosConsent({'gtmCode':'GTM-XXXXXX'});</script>
+<script>
+  BarnardosConsent({ gtmCode: "GTM-XXXXXX" });
+</script>
 ```
 
 Self hosting is recommended ~~but if it's not possible you can use:~~
 
 ~~```html
+
 <script src="https://unpkg.com/@barnardoswebteam/consent-banner@latest/consent-banner.es5.js"></script>
 <script>BarnardosConsent({'gtmCode':'GTM-XXXXXX'});</script>
-```~~
+
+````~~
 
 You can customise the standard consent banner by passing camelCase config variables in an options hash. See Option 1 above for option syntax. For example:
 
@@ -83,7 +88,7 @@ BarnardosConsent(
   }
 );
 </script>
-```
+````
 
 ### Updating
 

--- a/consent-banner.es5.js
+++ b/consent-banner.es5.js
@@ -2,7 +2,7 @@
 //common options routines
 function set_static_defaults(options, defaults) {
   Object.keys(defaults).forEach((key) => {
-    options[key] = options.hasOwnProperty(key) ? options[key] : defaults[key];
+    options[key] = options[key] || defaults[key];
   });
   return options;
 }
@@ -71,7 +71,9 @@ function barnardosCustomConsent(options) {
       value +
       "; expires=" +
       expires +
-      (options.restrictDomain ? ";domain=" + options.restrictDomain : "") +
+      (options.restrictDomain != "*"
+        ? ";domain=" + options.restrictDomain
+        : "") +
       "; path=/; SameSite=Strict";
   };
 

--- a/consent-banner.esm.js
+++ b/consent-banner.esm.js
@@ -1,20 +1,14 @@
 //common options routines
 function check(options) {
   let i = 1,
-    found = {},
     key;
   while ((key = arguments[i])) {
     const snakeCapsKey = key.replace(/([a-z])([A-Z])/g, "$1_$2").toUpperCase();
-    if (options.hasOwnProperty(key)) {
-      found[key] = options[key];
-      return found;
+    if (options[key]) {
+      return options[key];
     }
-    if (
-      typeof process !== "undefined" &&
-      process.env.hasOwnProperty(snakeCapsKey)
-    ) {
-      found[key] = process.env[snakeCapsKey];
-      return found;
+    if (typeof process !== "undefined" && process.env[snakeCapsKey]) {
+      return process.env[snakeCapsKey];
     }
     i++;
   }
@@ -23,8 +17,7 @@ function check(options) {
 
 const set_static_defaults = (options, defaults) => {
   Object.keys(defaults).forEach((key) => {
-    const found = check(options, key);
-    options[key] = found ? found[key] : defaults[key];
+    options[key] = check(options, key) || defaults[key];
   });
   return options;
 };
@@ -93,7 +86,9 @@ export const barnardosCustomConsent = (options) => {
       value +
       "; expires=" +
       expires +
-      (options.restrictDomain ? ";domain=" + options.restrictDomain : "") +
+      (options.restrictDomain != "*"
+        ? ";domain=" + options.restrictDomain
+        : "") +
       "; path=/; SameSite=Strict";
   };
 

--- a/consent-banner.esm.js
+++ b/consent-banner.esm.js
@@ -249,6 +249,7 @@ export const barnardosCustomConsent = (options) => {
     acceptButton.addEventListener("click", (e) => {
       closeConsentBanner();
       loadScripts();
+      options.reloadOnAccept && location.reload();
     });
   }
 

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -251,6 +251,7 @@ const barnardosCustomConsent = (options) => {
     acceptButton.addEventListener("click", (e) => {
       closeConsentBanner();
       loadScripts();
+      options.reloadOnAccept && location.reload();
     });
   }
 

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -5,13 +5,11 @@ function check(options) {
     key;
   while ((key = arguments[i])) {
     const snakeCapsKey = key.replace(/([a-z])([A-Z])/g, "$1_$2").toUpperCase();
-    if (options.hasOwnProperty(key)) {
-      found[key] = options[key];
-      return found;
+    if (options[key]) {
+      return options[key];
     }
-    if (process.env.hasOwnProperty(snakeCapsKey)) {
-      found[key] = process.env[snakeCapsKey];
-      return found;
+    if (process.env[snakeCapsKey]) {
+      return process.env[snakeCapsKey];
     }
     i++;
   }
@@ -20,8 +18,7 @@ function check(options) {
 
 const set_static_defaults = (options, defaults) => {
   Object.keys(defaults).forEach((key) => {
-    const found = check(options, key);
-    options[key] = found ? found[key] : defaults[key];
+    options[key] = check(options, key) || defaults[key];
   });
   return options;
 };
@@ -91,7 +88,9 @@ const barnardosCustomConsent = (options) => {
       value +
       "; expires=" +
       expires +
-      (options.restrictDomain ? ";domain=" + options.restrictDomain : "") +
+      (options.restrictDomain != "*"
+        ? ";domain=" + options.restrictDomain
+        : "") +
       "; path=/; SameSite=Strict";
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barnardos/customisable-consent-banner",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barnardos/customisable-consent-banner",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Customisable version of Barnardo's consent banner.",
   "main": "consent-banner.node.js",
   "scripts": {


### PR DESCRIPTION
The use of mixed boolean and string types on the same variable was causing trouble so I have altered the convention -- now '*' must be set explicitly if domain restriction is not required. 
Also fixed an omission by porting the refresh-page-on-accept behaviour from the es5 script where it was developed and tested, into the modules.